### PR TITLE
Update explainer.md to simplify response schema

### DIFF
--- a/PasskeyEndpointsWellKnownUrl/explainer.md
+++ b/PasskeyEndpointsWellKnownUrl/explainer.md
@@ -6,7 +6,7 @@ Author: [Tim Cappalli](https://github.com/timcappalli) &lt;tim.cappalli@microsof
 
 This document is intended as a starting point for engaging the community and standards bodies in developing collaborative solutions fit for standardization. As the solutions to problems described in this document progress along the standards-track, we will retain this document as an archive and use this section to keep the community up-to-date with the most current standards venue and content location of future work and discussions.
 
-- This document status: draft.01
+- This document status: draft.02
 - Current venue: tbd
 - Current version: early draft
 
@@ -65,75 +65,22 @@ A successful response would return:
 - Content-Type: `application/json`
 - a JSON object containing one or both members defined in the table below
 
-| Member   | JSON Type | Required/Optional | Description                                                                                                            |
-| :------- | :-------- | :---------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `enroll` | Object    | Optional          | an object defining URLs for web and apps which take the user directly to a passkey creation flow                       |
-| `manage` | Object    | Optional          | an object defining URLs for web and apps which take the user directly to the passkey management page for their account |
+| Member   | JSON Type | Format | Required/Optional | Description                                                                         |
+| :------- | :-------- | :----- | :---------------- | ------------------------------------------------------------------------------------|
+| `enroll` | String    | URL    | Optional          | a URL that takes the user directly to the passkey creation page for their account   |
+| `manage` | String    | URL    | Optional          | a URL that takes the user directly to the passkey management page for their account |
 
-`enroll` object:
+### Example
 
-| Member    | JSON Type | Format | Required/Optional | Description                                                                                   |
-| :-------- | :-------- | :----- | :---------------- | --------------------------------------------------------------------------------------------- |
-| `web`     | String    | URL    | Optional          | a URL that takes the user directly to the web-based passkey management page for their account |
-| `android` | String    | URL    | Optional          | an Android specific URL that takes the user directly to a passkey creation flow in an app     |
-| `ios`     | String    | URL    | Optional          | an iOS/iPadOS specific URL that takes the user directly to a passkey creation flow in an app  |
-| `windows` | String    | URL    | Optional          | a Windows specific URL that takes the user directly to a passkey creation flow in an app      |
-| `macos`   | String    | URL    | Optional          | a macOS specific URL that takes the user directly to a passkey creation flow in an app        |
-
-`manage` object:
-
-| Member    | JSON Type | Format | Required/Optional | Description                                                                                      |
-| :-------- | :-------- | :----- | :---------------- | ------------------------------------------------------------------------------------------------ |
-| `web`     | String    | URL    | Optional          | a URL that takes the user directly to the web-based passkey management page for their account    |
-| `android` | String    | URL    | Optional          | an Android specific URL that takes the user directly to the passkey management page in an app    |
-| `ios`     | String    | URL    | Optional          | an iOS/iPadOS specific URL that takes the user directly to the passkey management page in an app |
-| `windows` | String    | URL    | Optional          | a Windows specific URL that takes the user directly to the passkey management page in an app     |
-| `macos`   | String    | URL    | Optional          | a macOS specific URL that takes the user directly to the passkey management page in an app       |
-
-### Example 1
-
-For the Relying Party `https://example.com`, which has a website and native apps across all platforms, the well-known URL would be `https://example.com/.well-known/passkey-endpoints` with a response of:
+For the Relying Party `https://example.com`, the well-known URL would be `https://example.com/.well-known/passkey-endpoints` with a response of:
 
 ```http
 HTTP/1.1 200 OK
 Content-Type: application/json
  {
-    "enroll": {
-        "web": "https://example.com/account/manage/passkeys/create",
-        "android": "com.example.android.myapp://account/passkeys/create",
-        "ios": "com.example.ios.myapp://account/passkeys/create",
-        "windows": "myapp://account/passkeys/create",
-        "macos": "myapp://account/passkeys/create"
-    },
-    "manage": {
-        "web": "https://example.com/account/manage/passkeys",
-        "android": "com.example.android.myapp://account/passkeys",
-        "ios": "com.example.ios.myapp://account/passkeys",
-        "windows": "myapp://account/passkeys",
-        "macos": "myapp://account/passkeys"
-    }
+    "enroll": "https://example.com/account/manage/passkeys/create",
+    "manage": "https://example.com/account/manage/passkeys"
  }
-```
-
-### Example 2
-
-For the replying party `https://example.org`, with only web and mobile apps, the well-known URL would be `https://example.org/.well-known/passkey-endpoints` with a response of:
-
-```http
-HTTP/1.1 200 OK
-Content-Type: application/json
-{
-    "enroll": {
-        "web": "https://example.org/myaccount/manage/passkeys/create",
-        "android": "org.example.android.myapp://myaccount/passkeys/create",
-        "ios": "org.example.ios.myapp://myaccount/passkeys/create"
-    },
-    "manage": {
-        "web": "https://example.org/myaccount/manage/passkeys",
-        "android": "org.example.android.myapp://myaccount/passkeys",
-        "ios": "org.example.ios.myapp://myaccount/passkeys"
-    }
-}
 ```
 
 ### File Location


### PR DESCRIPTION
Reverting back to single URL each for `enroll` and `manage` and apps on mobile and desktop platforms need to decide whether or not to intercept those URLs associated with their own domains. 